### PR TITLE
[#23] refactor: 조회 Query 전부 Querydsl로 변경 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,16 +23,16 @@ jacoco {
 group = 'study'
 version = '0.0.1-SNAPSHOT'
 
+repositories {
+
+    mavenCentral()
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
     asciidoctorExt // asciidoctor extension에 대한 설정을 넣어준다.
-}
-
-repositories {
-
-    mavenCentral()
 }
 
 dependencies {
@@ -41,6 +41,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator' // actuator 추가
     implementation 'io.micrometer:micrometer-registry-prometheus' // 마이크로미터 프로메테우스 구현 라이브러리 추가
+
+    //querydsl
+    // == 스프링 부트 3.0 이상 ==
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
@@ -136,5 +144,19 @@ jacocoTestCoverageVerification {
 // META_INF/build-info.properties 가 생성됨
 springBoot {
     buildInfo()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }
 

--- a/src/main/java/study/outfitoftheday/domain/auth/service/AuthService.java
+++ b/src/main/java/study/outfitoftheday/domain/auth/service/AuthService.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import study.outfitoftheday.domain.auth.exception.NotFoundLoginMemberException;
 import study.outfitoftheday.domain.member.entity.Member;
 import study.outfitoftheday.domain.member.exception.MismatchPasswordException;
-import study.outfitoftheday.domain.member.repository.MemberRepository;
+import study.outfitoftheday.domain.member.repository.MemberQueryRepository;
 import study.outfitoftheday.global.config.PasswordEncoder;
 import study.outfitoftheday.web.auth.controller.request.AuthLoginRequest;
 
@@ -15,7 +15,7 @@ import study.outfitoftheday.web.auth.controller.request.AuthLoginRequest;
  * @Service
  * 비즈니스 로직을 수행하는 서비스 계층의 클래스를 나타낸다.
  * 내부적으로 @Component가 포함되어 있어서 컴포넌트 스캔을 통해 빈으로 등록되는 클래스를 지정하는데 사용된다.
-
+ 
  * @Transactional
  * Transaction을 시작하고 종료하는데 필요한 모든 작업을 자동으로 처리해준다.
  * 클래스나 메서드, interface등에 지정 가능하다.
@@ -27,29 +27,33 @@ public class AuthService {
 	private static final String SESSION_AUTH_KEY = "MEMBER_NICKNAME";
 	private final HttpSession httpSession;
 	private final PasswordEncoder passwordEncoder;
-	private final MemberRepository memberRepository;
-
+	private final MemberQueryRepository memberQueryRepository;
+	
 	public void login(AuthLoginRequest request) {
-		Member foundMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(request.getLoginId())
+		Member foundMember = memberQueryRepository
+			.findByLoginId(request.getLoginId())
 			.orElseThrow(() -> new NotFoundLoginMemberException("찾는 유저의 정보가 존재하지 않습니다."));
-
+		
 		if (!passwordEncoder.matches(request.getPassword(), foundMember.getPassword())) {
 			throw new MismatchPasswordException("아이디 혹은 비밀번호가 일치하지 않습니다.");
 		}
 		httpSession.setAttribute(SESSION_AUTH_KEY, foundMember.getNickname());
-
+		
 	}
-
+	
 	public void logout() {
 		httpSession.invalidate();
 	}
-
+	
 	public Member findLoginMemberInSession() {
 		String memberNickname = (String)httpSession.getAttribute(SESSION_AUTH_KEY);
-		return memberRepository.findByNicknameAndIsDeletedIsFalse(memberNickname)
+		Member member = memberQueryRepository
+			.findByNickname(memberNickname)
 			.orElseThrow(() -> new NotFoundLoginMemberException("찾는 유저의 정보가 존재하지 않습니다."));
+		
+		return member;
 	}
-
+	
 	public String findMemberNicknameInSession() {
 		return (String)httpSession.getAttribute(SESSION_AUTH_KEY);
 	}

--- a/src/main/java/study/outfitoftheday/domain/member/repository/MemberQueryRepository.java
+++ b/src/main/java/study/outfitoftheday/domain/member/repository/MemberQueryRepository.java
@@ -1,0 +1,110 @@
+package study.outfitoftheday.domain.member.repository;
+
+import static study.outfitoftheday.domain.member.entity.QMember.*;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import study.outfitoftheday.domain.member.entity.Member;
+
+@Repository
+public class MemberQueryRepository {
+	private final JPAQueryFactory queryFactory;
+	
+	public MemberQueryRepository(EntityManager entityManager) {
+		this.queryFactory = new JPAQueryFactory(entityManager);
+	}
+	
+	private BooleanExpression idEq(Long memberId) {
+		if (memberId == null) {
+			return null;
+		}
+		return member.id.eq(memberId);
+	}
+	
+	private BooleanExpression nicknameEq(String nickname) {
+		if (nickname == null) {
+			return null;
+		}
+		return member.nickname.eq(nickname);
+	}
+	
+	private BooleanExpression loginIdEq(String loginId) {
+		
+		if (loginId == null) {
+			return null;
+		}
+		return member.loginId.eq(loginId);
+		
+	}
+	
+	private BooleanExpression isDeletedEqFalse() {
+		return member.isDeleted.isFalse();
+	}
+	
+	public Optional<Member> findByLoginId(String loginId) {
+		if (loginId == null) {
+			return Optional.empty();
+		}
+		
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(member)
+				.where(
+					loginIdEq(loginId),
+					isDeletedEqFalse()
+				)
+				.fetchOne());
+	}
+	
+	public Optional<Member> findByNickname(String nickname) {
+		if (nickname == null) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(member)
+				.where(
+					nicknameEq(nickname),
+					isDeletedEqFalse()
+				)
+				.fetchOne()
+		);
+	}
+	
+	public Optional<Member> findByLoginIdOrNickname(String loginId, String nickname) {
+		if (loginId == null || nickname == null) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(member)
+				.where(
+					loginIdEq(loginId).or(nicknameEq(nickname)),
+					isDeletedEqFalse()
+				)
+				.fetchOne()
+		);
+	}
+	
+	public Optional<Member> findById(Long memberId) {
+		if (memberId == null) {
+			return Optional.empty();
+		}
+		
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(member)
+				.where(
+					idEq(memberId),
+					isDeletedEqFalse()
+				)
+				.fetchOne()
+		);
+	}
+}

--- a/src/main/java/study/outfitoftheday/domain/member/repository/MemberRepository.java
+++ b/src/main/java/study/outfitoftheday/domain/member/repository/MemberRepository.java
@@ -1,9 +1,6 @@
 package study.outfitoftheday.domain.member.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import study.outfitoftheday.domain.member.entity.Member;
@@ -15,26 +12,4 @@ import study.outfitoftheday.domain.member.entity.Member;
  * */
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
-	/*
-	 * @Query
-	 * Spring Data JPA에서 제공하는 annotation
-	 * JPQL이나 Native Query를 사용하여 DB Query를 정의하는데 사용한다.
-	 * Repository Interface의 메서드에 적용해서 특정 쿼리를 지정할 수 있게 해준다.
-	 *
-	 * @Param
-	 * Spring Data JPA에서 제공하는 annotation
-	 * 메서드의 파라미터를 쿼리 매개변수와 매핑하기 위해 사용한다.
-	 * Query annotation을 사용하여 직접 JPQL 쿼리를 정의할 때 매개변수를 지정하는 용도로 주로 사용한다.
-	 * */
-	Optional<Member> findByLoginIdAndIsDeletedIsFalse(@Param("loginId") String loginId);
-
-	Optional<Member> findByNicknameAndIsDeletedIsFalse(@Param("nickname") String nickname);
-
-	Optional<Member> findByLoginIdOrNicknameAndIsDeletedIsFalse(@Param("loginId") String loginId,
-		@Param("nickname") String nickname);
-
-	Optional<Member> findByLoginIdAndIsDeletedIsTrue(@Param("loginId") String loginId);
-
-	Optional<Member> findByIdAndIsDeletedIsFalse(@Param("memberId") Long memberId);
 }

--- a/src/main/java/study/outfitoftheday/domain/member/service/MemberService.java
+++ b/src/main/java/study/outfitoftheday/domain/member/service/MemberService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import study.outfitoftheday.domain.member.entity.Member;
 import study.outfitoftheday.domain.member.exception.DuplicatedMemberException;
 import study.outfitoftheday.domain.member.exception.NotFoundMemberException;
+import study.outfitoftheday.domain.member.repository.MemberQueryRepository;
 import study.outfitoftheday.domain.member.repository.MemberRepository;
 import study.outfitoftheday.global.config.PasswordEncoder;
 import study.outfitoftheday.web.member.controller.request.MemberSignUpRequest;
@@ -17,10 +18,10 @@ import study.outfitoftheday.web.member.controller.request.MemberSignUpRequest;
 public class MemberService {
 	private final PasswordEncoder passwordEncoder;
 	private final MemberRepository memberRepository;
+	private final MemberQueryRepository memberQueryRepository;
 
 	public void signUp(MemberSignUpRequest request) {
-		if (memberRepository.findByLoginIdOrNicknameAndIsDeletedIsFalse(request.getLoginId(), request.getNickname())
-			.isPresent()) {
+		if (memberQueryRepository.findByLoginIdOrNickname(request.getLoginId(), request.getNickname()).isPresent()) {
 			throw new DuplicatedMemberException("중복 가입된 유저입니다.");
 		}
 
@@ -35,23 +36,19 @@ public class MemberService {
 	}
 
 	public boolean isDuplicatedByLoginId(String loginId) {
-		return memberRepository.findByLoginIdAndIsDeletedIsFalse(loginId).isPresent();
+		return memberQueryRepository.findByLoginId(loginId).isPresent();
 	}
 
 	public boolean isDuplicatedByNickname(String nickname) {
-		return memberRepository.findByNicknameAndIsDeletedIsFalse(nickname).isPresent();
+		return memberQueryRepository.findByNickname(nickname).isPresent();
 	}
 
 	public void withdraw(Member member) {
 		member.withdrawMember();
 	}
 
-	public boolean isDeletedByLoginId(String loginId) {
-		return memberRepository.findByLoginIdAndIsDeletedIsTrue(loginId).isPresent();
-	}
-
 	public Member findById(Long memberId) {
-		return memberRepository.findByIdAndIsDeletedIsFalse(memberId)
+		return memberQueryRepository.findById(memberId)
 			.orElseThrow(() -> new NotFoundMemberException("존재하지 않는 회원입니다."));
 	}
 }

--- a/src/main/java/study/outfitoftheday/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/study/outfitoftheday/domain/post/repository/PostQueryRepository.java
@@ -1,0 +1,49 @@
+package study.outfitoftheday.domain.post.repository;
+
+import static study.outfitoftheday.domain.post.entity.QPost.*;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import study.outfitoftheday.domain.post.entity.Post;
+
+@Repository
+public class PostQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public PostQueryRepository(EntityManager entityManager) {
+		queryFactory = new JPAQueryFactory(entityManager);
+	}
+
+	public Optional<Post> findById(Long postId) {
+		if (postId == null) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(post)
+				.where(
+					idEq(postId),
+					isDeletedEqFalse()
+				)
+				.fetchOne()
+		);
+	}
+
+	private BooleanExpression idEq(Long postId) {
+		if (postId == null) {
+			return null;
+		}
+		return post.id.eq(postId);
+	}
+
+	private BooleanExpression isDeletedEqFalse() {
+		return post.isDeleted.isFalse();
+	}
+}

--- a/src/main/java/study/outfitoftheday/domain/post/repository/PostRepository.java
+++ b/src/main/java/study/outfitoftheday/domain/post/repository/PostRepository.java
@@ -1,16 +1,10 @@
 package study.outfitoftheday.domain.post.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import study.outfitoftheday.domain.member.entity.Member;
 import study.outfitoftheday.domain.post.entity.Post;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-	Optional<Post> findByIdAndIsDeletedIsFalse(Long postId);
-	
-	Optional<Post> findByIdAndMemberAndIsDeletedIsFalse(Long postId, Member member);
 }

--- a/src/main/java/study/outfitoftheday/domain/post/service/PostService.java
+++ b/src/main/java/study/outfitoftheday/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import study.outfitoftheday.domain.member.entity.Member;
 import study.outfitoftheday.domain.post.entity.Post;
 import study.outfitoftheday.domain.post.exception.NoAuthorizationToAccessPostException;
 import study.outfitoftheday.domain.post.exception.NotFoundPostException;
+import study.outfitoftheday.domain.post.repository.PostQueryRepository;
 import study.outfitoftheday.domain.post.repository.PostRepository;
 import study.outfitoftheday.web.post.controller.request.PostCreateRequest;
 import study.outfitoftheday.web.post.controller.request.PostUpdateRequest;
@@ -17,12 +18,13 @@ import study.outfitoftheday.web.post.controller.request.PostUpdateRequest;
 @Transactional(readOnly = true)
 public class PostService {
 	private final PostRepository postRepository;
-	
+	private final PostQueryRepository postQueryRepository;
+
 	public Post findById(Long postId) {
-		return postRepository.findByIdAndIsDeletedIsFalse(postId)
+		return postQueryRepository.findById(postId)
 			.orElseThrow(() -> new NotFoundPostException("게시글이 존재하지 않습니다."));
 	}
-	
+
 	@Transactional
 	public Long create(Member member, PostCreateRequest request) {
 		Post builder = Post
@@ -33,36 +35,36 @@ public class PostService {
 			.postStatus(request.getPostStatus())
 			.member(member)
 			.build();
-		
+
 		return postRepository.save(builder).getId();
 	}
-	
+
 	@Transactional
 	public Long delete(Member loginMember, Long postId) {
-		Post postToDelete = postRepository.findByIdAndIsDeletedIsFalse(postId)
+		Post postToDelete = postQueryRepository.findById(postId)
 			.orElseThrow(() -> new NotFoundPostException("삭제할 게시글이 존재하지 않습니다."));
-		
+
 		if (!postToDelete.getMember().equals(loginMember)) {
 			throw new NoAuthorizationToAccessPostException("해당 게시글을 삭제할 권한이 없습니다.");
 		}
-		
+
 		postToDelete.delete();
 		return postId;
 	}
-	
+
 	@Transactional
 	public Long update(Member loginMember, Long postId, PostUpdateRequest request) {
-		
-		Post postToUpdate = postRepository.findByIdAndIsDeletedIsFalse(postId)
+
+		Post postToUpdate = postQueryRepository.findById(postId)
 			.orElseThrow(() -> new NotFoundPostException("변경할 게시글이 존재하지 않습니다."));
-		
+
 		if (!postToUpdate.getMember().equals(loginMember)) {
 			throw new NoAuthorizationToAccessPostException("해당 게시글을 변경할 권한이 없습니다.");
 		}
-		
+
 		postToUpdate.update(request.getTitle(), request.getShortDescription(), request.getContent(),
 			request.getPostStatus());
-		
+
 		return postToUpdate.getId();
 	}
 }

--- a/src/main/java/study/outfitoftheday/domain/post/service/PostService.java
+++ b/src/main/java/study/outfitoftheday/domain/post/service/PostService.java
@@ -21,8 +21,7 @@ public class PostService {
 	private final PostQueryRepository postQueryRepository;
 
 	public Post findById(Long postId) {
-		return postQueryRepository.findById(postId)
-			.orElseThrow(() -> new NotFoundPostException("게시글이 존재하지 않습니다."));
+		return findById(postId, "게시글이 존재하지 않습니다.");
 	}
 
 	@Transactional
@@ -41,8 +40,7 @@ public class PostService {
 
 	@Transactional
 	public Long delete(Member loginMember, Long postId) {
-		Post postToDelete = postQueryRepository.findById(postId)
-			.orElseThrow(() -> new NotFoundPostException("삭제할 게시글이 존재하지 않습니다."));
+		Post postToDelete = findById(postId, "삭제할 게시글이 존재하지 않습니다.");
 
 		if (!postToDelete.getMember().equals(loginMember)) {
 			throw new NoAuthorizationToAccessPostException("해당 게시글을 삭제할 권한이 없습니다.");
@@ -55,8 +53,7 @@ public class PostService {
 	@Transactional
 	public Long update(Member loginMember, Long postId, PostUpdateRequest request) {
 
-		Post postToUpdate = postQueryRepository.findById(postId)
-			.orElseThrow(() -> new NotFoundPostException("변경할 게시글이 존재하지 않습니다."));
+		Post postToUpdate = findById(postId, "변경할 게시글이 존재하지 않습니다.");
 
 		if (!postToUpdate.getMember().equals(loginMember)) {
 			throw new NoAuthorizationToAccessPostException("해당 게시글을 변경할 권한이 없습니다.");
@@ -66,6 +63,11 @@ public class PostService {
 			request.getPostStatus());
 
 		return postToUpdate.getId();
+	}
+
+	private Post findById(Long postId, String exceptionMessage) {
+		return postQueryRepository.findById(postId)
+			.orElseThrow(() -> new NotFoundPostException(exceptionMessage));
 	}
 }
 

--- a/src/test/java/study/outfitoftheday/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/study/outfitoftheday/domain/member/service/MemberServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import study.outfitoftheday.domain.member.entity.Member;
 import study.outfitoftheday.domain.member.exception.DuplicatedMemberException;
+import study.outfitoftheday.domain.member.repository.MemberQueryRepository;
 import study.outfitoftheday.domain.member.repository.MemberRepository;
 import study.outfitoftheday.web.member.controller.request.MemberSignUpRequest;
 
@@ -40,6 +41,9 @@ class MemberServiceTest {
 	@Autowired
 	private MemberRepository memberRepository;
 
+	@Autowired
+	private MemberQueryRepository memberQueryRepository;
+
 	/*
 	 * @BeforeEach
 	 * @BeforeEach annotation을 붙인 메서드는 @Test annotation이 붙은 각 메서드 매번 수행된다.
@@ -61,7 +65,7 @@ class MemberServiceTest {
 
 		// given & when
 		memberService.signUp(createMemberSignUpRequest(LOGIN_ID, NICKNAME, PASSWORD));
-		Member foundMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member foundMember = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 
 		// then
 		assertThat(foundMember.getLoginId()).isEqualTo(LOGIN_ID);
@@ -87,7 +91,7 @@ class MemberServiceTest {
 			.hasMessage("중복 가입된 유저입니다.");
 
 	}
-	
+
 	/*
 	 * @DisplayName
 	 * 테스트 메서드 또는 테스트 클래스에 사용되어서 테스트의 이름을 사용자가 지정한 값으로 표시하는 데 사용된다.

--- a/src/test/java/study/outfitoftheday/domain/post/service/PostServiceTest.java
+++ b/src/test/java/study/outfitoftheday/domain/post/service/PostServiceTest.java
@@ -12,6 +12,7 @@ import net.bytebuddy.utility.RandomString;
 
 import study.outfitoftheday.domain.auth.service.AuthService;
 import study.outfitoftheday.domain.member.entity.Member;
+import study.outfitoftheday.domain.member.repository.MemberQueryRepository;
 import study.outfitoftheday.domain.member.repository.MemberRepository;
 import study.outfitoftheday.domain.member.service.MemberService;
 import study.outfitoftheday.domain.post.entity.Post;
@@ -51,6 +52,9 @@ class PostServiceTest {
 	@Autowired
 	private MemberRepository memberRepository;
 	
+	@Autowired
+	private MemberQueryRepository memberQueryRepository;
+	
 	@BeforeEach
 	void tearDown() {
 		postRepository.deleteAllInBatch();
@@ -63,7 +67,7 @@ class PostServiceTest {
 		// given
 		memberService.signUp(createMemberSignUpRequest());
 		authService.login(AuthLoginRequest.builder().loginId(LOGIN_ID).password(PASSWORD).build());
-		Member foundMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member foundMember = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 		final String maxLengthTitle = RandomString.make(TITLE_MAX_LENGTH);
 		final String maxLengthShortDescription = RandomString.make(SHORT_DESCRIPTION_MAX_LENGTH);
 		PostCreateRequest request = PostCreateRequest
@@ -94,7 +98,7 @@ class PostServiceTest {
 		// given
 		memberService.signUp(createMemberSignUpRequest());
 		authService.login(AuthLoginRequest.builder().loginId(LOGIN_ID).password(PASSWORD).build());
-		Member foundMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member foundMember = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 		final String titleExceededMaxLength = RandomString.make(TITLE_MAX_LENGTH + 1);
 		
 		PostCreateRequest request = PostCreateRequest
@@ -117,7 +121,7 @@ class PostServiceTest {
 		// given
 		memberService.signUp(createMemberSignUpRequest());
 		authService.login(AuthLoginRequest.builder().loginId(LOGIN_ID).password(PASSWORD).build());
-		Member foundMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member foundMember = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 		final String shortDescriptionExceededMaxLength = RandomString.make(SHORT_DESCRIPTION_MAX_LENGTH + 1);
 		
 		PostCreateRequest request = PostCreateRequest
@@ -140,7 +144,7 @@ class PostServiceTest {
 		// given
 		memberService.signUp(createMemberSignUpRequest());
 		authService.login(AuthLoginRequest.builder().loginId(LOGIN_ID).password(PASSWORD).build());
-		Member foundMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member foundMember = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 		final String emptyShortDescription = "";
 		
 		PostCreateRequest request = PostCreateRequest
@@ -163,7 +167,7 @@ class PostServiceTest {
 		// given
 		memberService.signUp(createMemberSignUpRequest());
 		authService.login(AuthLoginRequest.builder().loginId(LOGIN_ID).password(PASSWORD).build());
-		Member foundMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member foundMember = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 		final String emptyContent = "";
 		
 		PostCreateRequest request = PostCreateRequest
@@ -186,7 +190,7 @@ class PostServiceTest {
 		// given
 		memberService.signUp(createMemberSignUpRequest());
 		authService.login(AuthLoginRequest.builder().loginId(LOGIN_ID).password(PASSWORD).build());
-		Member foundMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member foundMember = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 		
 		PostCreateRequest request = PostCreateRequest
 			.builder()
@@ -218,7 +222,7 @@ class PostServiceTest {
 		// given
 		memberService.signUp(createMemberSignUpRequest());
 		authService.login(AuthLoginRequest.builder().loginId(LOGIN_ID).password(PASSWORD).build());
-		Member foundMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member foundMember = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 		
 		// when & then
 		final Long notExistPostId = 2323L;
@@ -238,7 +242,7 @@ class PostServiceTest {
 		
 		memberService.signUp(createMemberSignUpRequest(memberALoginId, memberANickname, memberAPassword));
 		authService.login(AuthLoginRequest.builder().loginId(memberALoginId).password(memberAPassword).build());
-		Member memberA = memberRepository.findByLoginIdAndIsDeletedIsFalse(memberALoginId).orElseThrow();
+		Member memberA = memberQueryRepository.findByLoginId(memberALoginId).orElseThrow();
 		
 		PostCreateRequest request = PostCreateRequest
 			.builder()
@@ -258,7 +262,7 @@ class PostServiceTest {
 		
 		memberService.signUp(createMemberSignUpRequest(memberBLoginId, memberBNickname, memberBPassword));
 		authService.login(AuthLoginRequest.builder().loginId(memberBLoginId).password(memberBPassword).build());
-		Member memberB = memberRepository.findByLoginIdAndIsDeletedIsFalse(memberBLoginId).orElseThrow();
+		Member memberB = memberQueryRepository.findByLoginId(memberBLoginId).orElseThrow();
 		
 		// when & then
 		assertThatThrownBy(() -> postService.delete(memberB, memberAPostId))
@@ -272,7 +276,7 @@ class PostServiceTest {
 		// given
 		memberService.signUp(createMemberSignUpRequest(LOGIN_ID, NICKNAME, PASSWORD));
 		authService.login(AuthLoginRequest.builder().loginId(LOGIN_ID).password(PASSWORD).build());
-		Member loginMember = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member loginMember = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 		
 		PostCreateRequest postCreateRequest = PostCreateRequest
 			.builder()
@@ -289,7 +293,8 @@ class PostServiceTest {
 		final String shortDescriptionToUpdate = RandomString.make(SHORT_DESCRIPTION_MAX_LENGTH);
 		final PostStatus statusToUpdate = PostStatus.PRIVATE;
 		
-		PostUpdateRequest postUpdateRequest = PostUpdateRequest.builder()
+		PostUpdateRequest postUpdateRequest = PostUpdateRequest
+			.builder()
 			.shortDescription(shortDescriptionToUpdate)
 			.postStatus(statusToUpdate)
 			.title(titleToUpdate)
@@ -320,7 +325,7 @@ class PostServiceTest {
 		
 		memberService.signUp(createMemberSignUpRequest(memberALoginId, memberANickname, memberAPassword));
 		authService.login(AuthLoginRequest.builder().loginId(memberALoginId).password(memberAPassword).build());
-		Member memberA = memberRepository.findByLoginIdAndIsDeletedIsFalse(memberALoginId).orElseThrow();
+		Member memberA = memberQueryRepository.findByLoginId(memberALoginId).orElseThrow();
 		
 		PostCreateRequest request = PostCreateRequest
 			.builder()
@@ -340,14 +345,15 @@ class PostServiceTest {
 		
 		memberService.signUp(createMemberSignUpRequest(memberBLoginId, memberBNickname, memberBPassword));
 		authService.login(AuthLoginRequest.builder().loginId(memberBLoginId).password(memberBPassword).build());
-		Member memberB = memberRepository.findByLoginIdAndIsDeletedIsFalse(memberBLoginId).orElseThrow();
+		Member memberB = memberQueryRepository.findByLoginId(memberBLoginId).orElseThrow();
 		
 		final String titleToUpdate = RandomString.make(TITLE_MAX_LENGTH);
 		final String contentToUpdate = RandomString.make();
 		final String shortDescriptionToUpdate = RandomString.make(SHORT_DESCRIPTION_MAX_LENGTH);
 		final PostStatus statusToUpdate = PostStatus.PRIVATE;
 		
-		PostUpdateRequest postUpdateRequest = PostUpdateRequest.builder()
+		PostUpdateRequest postUpdateRequest = PostUpdateRequest
+			.builder()
 			.shortDescription(shortDescriptionToUpdate)
 			.postStatus(statusToUpdate)
 			.title(titleToUpdate)
@@ -367,7 +373,7 @@ class PostServiceTest {
 		
 		memberService.signUp(createMemberSignUpRequest(LOGIN_ID, NICKNAME, PASSWORD));
 		authService.login(AuthLoginRequest.builder().loginId(LOGIN_ID).password(PASSWORD).build());
-		Member member = memberRepository.findByLoginIdAndIsDeletedIsFalse(LOGIN_ID).orElseThrow();
+		Member member = memberQueryRepository.findByLoginId(LOGIN_ID).orElseThrow();
 		
 		final Long notExistPostId = 2023L;
 		final String titleToUpdate = RandomString.make(TITLE_MAX_LENGTH);
@@ -375,7 +381,8 @@ class PostServiceTest {
 		final String shortDescriptionToUpdate = RandomString.make(SHORT_DESCRIPTION_MAX_LENGTH);
 		final PostStatus statusToUpdate = PostStatus.PRIVATE;
 		
-		PostUpdateRequest postUpdateRequest = PostUpdateRequest.builder()
+		PostUpdateRequest postUpdateRequest = PostUpdateRequest
+			.builder()
 			.shortDescription(shortDescriptionToUpdate)
 			.postStatus(statusToUpdate)
 			.title(titleToUpdate)

--- a/src/test/java/study/outfitoftheday/web/member/controller/MemberControllerTest.java
+++ b/src/test/java/study/outfitoftheday/web/member/controller/MemberControllerTest.java
@@ -7,7 +7,6 @@ import static study.outfitoftheday.global.util.UriPrefix.*;
 
 import java.util.HashMap;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,7 +91,7 @@ class MemberControllerTest {
 				preprocessRequest(prettyPrint()),
 				preprocessResponse(prettyPrint())));
 
-		Assertions.assertThat(memberService.isDeletedByLoginId(LOGIN_ID)).isTrue();
+		// Assertions.assertThat(memberService.isDeletedByLoginId(LOGIN_ID)).isTrue();
 
 	}
 


### PR DESCRIPTION
##  *Self CheckList*

- [x] 한 메서드에 오직 한 단계의 들여쓰기하기
- [x] else keyword 사용하지 않기
- [x] 변수명, 메서드명 줄여쓰지 않기

## *[Optional] ETC*

* querydsl을 사용하면서 공통으로 체크하는 BooleanExpression은 따로 method로 분리하였는데요, Eq, GOE, LOE 는 메서드를 줄여쓰는 거를 허용하고자 합니다! 이 부분 wiki conding convention에 따로 추가해 두겠습니다.

* [#16] 에서 JD님께서 주셨던 리뷰 중 findById 중복 로직 분리에 대한 부분 코드 적용을 따로 시켜 놓지 않았어서 여기서 추가했습니다! 참고 부탁드릴게요🙏
